### PR TITLE
topic/rename

### DIFF
--- a/contracts/incentives/PullRewardsIncentivesController.sol
+++ b/contracts/incentives/PullRewardsIncentivesController.sol
@@ -9,8 +9,8 @@ import {BaseIncentivesController} from './base/BaseIncentivesController.sol';
 
 /**
  * @title PullRewardsIncentivesController
- * @notice Distributor contract for ERC20 rewards to the Aave protocol participants that pulls ERC20 from external account
- * @author Aave
+ * @notice Distributor contract for ERC20 rewards to the protocol participants that pulls ERC20 from external account
+ * @author Starlay
  **/
 contract PullRewardsIncentivesController is
   BaseIncentivesController
@@ -26,7 +26,7 @@ contract PullRewardsIncentivesController is
   {}
 
   /**
-   * @dev Initialize AaveIncentivesController
+   * @dev Initialize BaseIncentivesController
    * @param rewardsVault rewards vault to pull ERC20 funds
    **/
   function initialize(address rewardsVault) external initializer {

--- a/contracts/incentives/StakedTokenIncentivesController.sol
+++ b/contracts/incentives/StakedTokenIncentivesController.sol
@@ -9,10 +9,10 @@ import {IStakedTokenWithConfig} from '../interfaces/IStakedTokenWithConfig.sol';
 
 /**
  * @title StakedTokenIncentivesController
- * @notice Distributor contract for rewards to the Aave protocol, using a staked token as rewards asset.
- * The contract stakes the rewards before redistributing them to the Aave protocol participants.
- * The reference staked token implementation is at https://github.com/aave/aave-stake-v2
- * @author Aave
+ * @notice Distributor contract for rewards to the protocol, using a staked token as rewards asset.
+ * The contract stakes the rewards before redistributing them to the protocol participants.
+ * The reference staked token implementation is at https://github.com/starlay-finance/starlay-stake
+ * @author Starlay
  **/
 contract StakedTokenIncentivesController is BaseIncentivesController {
   using SafeERC20 for IERC20;

--- a/contracts/incentives/base/BaseIncentivesController.sol
+++ b/contracts/incentives/base/BaseIncentivesController.sol
@@ -8,7 +8,7 @@ import {VersionedInitializable} from '@aave/aave-stake/contracts/utils/Versioned
 import {DistributionManager} from './DistributionManager.sol';
 import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
 import {IScaledBalanceToken} from '../../interfaces/IScaledBalanceToken.sol';
-import {IAaveIncentivesController} from '../../interfaces/IAaveIncentivesController.sol';
+import {IIncentivesController} from '../../interfaces/IIncentivesController.sol';
 
 /**
  * @title BaseIncentivesController
@@ -16,7 +16,7 @@ import {IAaveIncentivesController} from '../../interfaces/IAaveIncentivesControl
  * @author Aave
  **/
 abstract contract BaseIncentivesController is
-  IAaveIncentivesController,
+  IIncentivesController,
   VersionedInitializable,
   DistributionManager
 {
@@ -43,7 +43,7 @@ abstract contract BaseIncentivesController is
     REWARD_TOKEN = address(rewardToken);
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function configureAssets(address[] calldata assets, uint256[] calldata emissionsPerSecond)
     external
     override
@@ -63,7 +63,7 @@ abstract contract BaseIncentivesController is
     _configureAssets(assetsConfig);
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function handleAction(
     address user,
     uint256 totalSupply,
@@ -76,7 +76,7 @@ abstract contract BaseIncentivesController is
     }
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function getRewardsBalance(address[] calldata assets, address user)
     external
     view
@@ -96,7 +96,7 @@ abstract contract BaseIncentivesController is
     return unclaimedRewards;
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function claimRewards(
     address[] calldata assets,
     uint256 amount,
@@ -106,7 +106,7 @@ abstract contract BaseIncentivesController is
     return _claimRewards(assets, amount, msg.sender, msg.sender, to);
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function claimRewardsOnBehalf(
     address[] calldata assets,
     uint256 amount,
@@ -118,7 +118,7 @@ abstract contract BaseIncentivesController is
     return _claimRewards(assets, amount, msg.sender, user, to);
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function claimRewardsToSelf(address[] calldata assets, uint256 amount)
     external
     override
@@ -127,18 +127,18 @@ abstract contract BaseIncentivesController is
     return _claimRewards(assets, amount, msg.sender, msg.sender, msg.sender);
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function setClaimer(address user, address caller) external override onlyEmissionManager {
     _authorizedClaimers[user] = caller;
     emit ClaimerSet(user, caller);
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function getClaimer(address user) external view override returns (address) {
     return _authorizedClaimers[user];
   }
 
-  /// @inheritdoc IAaveIncentivesController
+  /// @inheritdoc IIncentivesController
   function getUserUnclaimedRewards(address _user) external view override returns (uint256) {
     return _usersUnclaimedRewards[_user];
   }

--- a/contracts/incentives/base/BaseIncentivesController.sol
+++ b/contracts/incentives/base/BaseIncentivesController.sol
@@ -13,7 +13,7 @@ import {IIncentivesController} from '../../interfaces/IIncentivesController.sol'
 /**
  * @title BaseIncentivesController
  * @notice Abstract contract template to build Distributors contracts for ERC20 rewards to protocol participants
- * @author Aave
+ * @author Starlay
  **/
 abstract contract BaseIncentivesController is
   IIncentivesController,

--- a/contracts/incentives/base/DistributionManager.sol
+++ b/contracts/incentives/base/DistributionManager.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.7.5;
 pragma experimental ABIEncoderV2;
 
-import {IAaveDistributionManager} from '../../interfaces/IAaveDistributionManager.sol';
+import {IDistributionManager} from '../../interfaces/IDistributionManager.sol';
 import {SafeMath} from '../../lib/SafeMath.sol';
 import {DistributionTypes} from '../../lib/DistributionTypes.sol';
 
@@ -11,7 +11,7 @@ import {DistributionTypes} from '../../lib/DistributionTypes.sol';
  * @notice Accounting contract to manage multiple staking distributions
  * @author Aave
  **/
-contract DistributionManager is IAaveDistributionManager {
+contract DistributionManager is IDistributionManager {
   using SafeMath for uint256;
 
   struct AssetData {
@@ -38,28 +38,28 @@ contract DistributionManager is IAaveDistributionManager {
     EMISSION_MANAGER = emissionManager;
   }
 
-  /// @inheritdoc IAaveDistributionManager
+  /// @inheritdoc IDistributionManager
   function setDistributionEnd(uint256 distributionEnd) external override onlyEmissionManager {
     _distributionEnd = distributionEnd;
     emit DistributionEndUpdated(distributionEnd);
   }
 
-  /// @inheritdoc IAaveDistributionManager
+  /// @inheritdoc IDistributionManager
   function getDistributionEnd() external view override returns (uint256) {
     return _distributionEnd;
   }
 
-  /// @inheritdoc IAaveDistributionManager
+  /// @inheritdoc IDistributionManager
   function DISTRIBUTION_END() external view override returns (uint256) {
     return _distributionEnd;
   }
 
-  /// @inheritdoc IAaveDistributionManager
+  /// @inheritdoc IDistributionManager
   function getUserAssetData(address user, address asset) public view override returns (uint256) {
     return assets[asset].users[user];
   }
 
-  /// @inheritdoc IAaveDistributionManager
+  /// @inheritdoc IDistributionManager
   function getAssetData(address asset) public view override returns (uint256, uint256, uint256) {
     return (assets[asset].index, assets[asset].emissionPerSecond, assets[asset].lastUpdateTimestamp);
   }

--- a/contracts/incentives/base/DistributionManager.sol
+++ b/contracts/incentives/base/DistributionManager.sol
@@ -9,7 +9,7 @@ import {DistributionTypes} from '../../lib/DistributionTypes.sol';
 /**
  * @title DistributionManager
  * @notice Accounting contract to manage multiple staking distributions
- * @author Aave
+ * @author Starlay
  **/
 contract DistributionManager is IDistributionManager {
   using SafeMath for uint256;

--- a/contracts/interfaces/IDistributionManager.sol
+++ b/contracts/interfaces/IDistributionManager.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import {DistributionTypes} from '../lib/DistributionTypes.sol';
 
-interface IAaveDistributionManager {
+interface IDistributionManager {
   
   event AssetConfigUpdated(address indexed asset, uint256 emission);
   event AssetIndexUpdated(address indexed asset, uint256 index);

--- a/contracts/interfaces/IIncentivesController.sol
+++ b/contracts/interfaces/IIncentivesController.sol
@@ -3,9 +3,9 @@ pragma solidity 0.7.5;
 
 pragma experimental ABIEncoderV2;
 
-import {IAaveDistributionManager} from '../interfaces/IAaveDistributionManager.sol';
+import {IDistributionManager} from '../interfaces/IDistributionManager.sol';
 
-interface IAaveIncentivesController is IAaveDistributionManager {
+interface IIncentivesController is IDistributionManager {
   event RewardsAccrued(address indexed user, uint256 amount);
 
   event RewardsClaimed(

--- a/contracts/mocks/ATokenMock.sol
+++ b/contracts/mocks/ATokenMock.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.7.5;
 pragma experimental ABIEncoderV2;
 
-import {IAaveIncentivesController} from '../interfaces/IAaveIncentivesController.sol';
+import {IIncentivesController} from '../interfaces/IIncentivesController.sol';
 import {DistributionTypes} from '../lib/DistributionTypes.sol';
 import {IAToken} from '@aave/aave-stake/contracts/interfaces/IAToken.sol';
 
 contract ATokenMock is IAToken {
-  IAaveIncentivesController public _aic;
+  IIncentivesController public _ic;
   uint256 internal _userBalance;
   uint256 internal _totalSupply;
 
@@ -19,8 +19,8 @@ contract ATokenMock is IAToken {
   event AssetIndexUpdated(address indexed asset, uint256 index);
   event UserIndexUpdated(address indexed user, address indexed asset, uint256 index);
 
-  constructor(IAaveIncentivesController aic) public {
-    _aic = aic;
+  constructor(IIncentivesController ic) public {
+    _ic = ic;
   }
 
   function handleActionOnAic(
@@ -28,7 +28,7 @@ contract ATokenMock is IAToken {
     uint256 totalSupply,
     uint256 userBalance
   ) external {
-    _aic.handleAction(user, totalSupply, userBalance);
+    _ic.handleAction(user, totalSupply, userBalance);
   }
 
   function doubleHandleActionOnAic(
@@ -36,8 +36,8 @@ contract ATokenMock is IAToken {
     uint256 totalSupply,
     uint256 userBalance
   ) external {
-    _aic.handleAction(user, totalSupply, userBalance);
-    _aic.handleAction(user, totalSupply, userBalance);
+    _ic.handleAction(user, totalSupply, userBalance);
+    _ic.handleAction(user, totalSupply, userBalance);
   }
 
   function setUserBalanceAndSupply(uint256 userBalance, uint256 totalSupply) public {

--- a/contracts/proposals/ProposalIncentivesExecutor.sol
+++ b/contracts/proposals/ProposalIncentivesExecutor.sol
@@ -5,7 +5,7 @@ pragma abicoder v2;
 import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
 import {ILendingPoolAddressesProvider} from '../interfaces/ILendingPoolAddressesProvider.sol';
 import {ILendingPoolConfigurator} from '../interfaces/ILendingPoolConfigurator.sol';
-import {IAaveIncentivesController} from '../interfaces/IAaveIncentivesController.sol';
+import {IIncentivesController} from '../interfaces/IIncentivesController.sol';
 import {IAaveEcosystemReserveController} from '../interfaces/IAaveEcosystemReserveController.sol';
 import {IProposalIncentivesExecutor} from '../interfaces/IProposalIncentivesExecutor.sol';
 import {DistributionTypes} from '../lib/DistributionTypes.sol';
@@ -65,8 +65,8 @@ contract ProposalIncentivesExecutor is IProposalIncentivesExecutor {
     emissions[11] = 129733796296296; //vDebtWETH
 
     ILendingPoolConfigurator poolConfigurator = ILendingPoolConfigurator(POOL_CONFIGURATOR);
-    IAaveIncentivesController incentivesController =
-      IAaveIncentivesController(INCENTIVES_CONTROLLER_PROXY_ADDRESS);
+    IIncentivesController incentivesController =
+      IIncentivesController(INCENTIVES_CONTROLLER_PROXY_ADDRESS);
     IAaveEcosystemReserveController ecosystemReserveController =
       IAaveEcosystemReserveController(ECO_RESERVE_ADDRESS);
 

--- a/helpers/contracts-accessors.ts
+++ b/helpers/contracts-accessors.ts
@@ -20,12 +20,12 @@ import {
 import { DefenderRelaySigner } from 'defender-relay-client/lib/ethers';
 import { Signer } from 'ethers';
 
-export const deployAaveIncentivesController = async (
-  [aavePsm, emissionManager]: [tEthereumAddress, tEthereumAddress],
+export const deployStakedTokenIncentivesController = async (
+  [psm, emissionManager]: [tEthereumAddress, tEthereumAddress],
   verify?: boolean,
   signer?: Signer | DefenderRelaySigner
 ) => {
-  const args: [string, string] = [aavePsm, emissionManager];
+  const args: [string, string] = [psm, emissionManager];
   const instance = await new StakedTokenIncentivesController__factory(
     signer || (await getFirstSigner())
   ).deploy(...args);
@@ -74,7 +74,7 @@ export const deployATokenMock = async (aicAddress: tEthereumAddress, slug: strin
 
 export const getMintableErc20 = getContractFactory<MintableErc20>(eContractid.MintableErc20);
 
-export const getAaveIncentivesController = getContractFactory<StakedTokenIncentivesController>(
+export const getStakedTokenIncentivesController = getContractFactory<StakedTokenIncentivesController>(
   eContractid.StakedTokenIncentivesController
 );
 

--- a/tasks/deployment/deploy-incentives-impl.ts
+++ b/tasks/deployment/deploy-incentives-impl.ts
@@ -1,15 +1,15 @@
 import { task } from 'hardhat/config';
 import { DefenderRelaySigner, DefenderRelayProvider } from 'defender-relay-client/lib/ethers';
-import { deployAaveIncentivesController } from '../../helpers/contracts-accessors';
+import { deployStakedTokenIncentivesController } from '../../helpers/contracts-accessors';
 import { getDefenderRelaySigner } from '../../helpers/defender-utils';
 
 // Mainnet addresses
-// const AAVE_STAKE = '0x4da27a545c0c5B758a6BA100e3a049001de870f5';
-// const AAVE_SHORT_EXECUTOR = '0xee56e2b3d491590b5b31738cc34d5232f378a8d5';
+// const STAKED_STARLAY = '0x4da27a545c0c5B758a6BA100e3a049001de870f5';
+// const STARLAY_SHORT_EXECUTOR = '0xee56e2b3d491590b5b31738cc34d5232f378a8d5';
 
 // Shibuya (astar network) addresses
-const AAVE_STAKE = '0x5d666338118763ca0cF6719F479491B76bc88131'; // StakedAave's (StakedTokenV2Rev3) proxy
-const AAVE_SHORT_EXECUTOR = '0x6543076E4315bd82129105890Bc49c18f496a528'; // PoolAdmin ref: https://docs.aave.com/developers/v/2.0/deployed-contracts/deployed-contracts#:~:text=Admin
+const STAKED_STARLAY = '0x5d666338118763ca0cF6719F479491B76bc88131'; // StakedAave's (StakedTokenV2Rev3) proxy
+const STARLAY_SHORT_EXECUTOR = '0x6543076E4315bd82129105890Bc49c18f496a528'; // PoolAdmin ref: https://docs.aave.com/developers/v/2.0/deployed-contracts/deployed-contracts#:~:text=Admin
 
 task('deploy-incentives-impl', 'Incentives controller implementation deployment').setAction(
   async (_, localBRE) => {
@@ -25,8 +25,8 @@ task('deploy-incentives-impl', 'Incentives controller implementation deployment'
       deployer = signer;
     }
 
-    const incentives = await deployAaveIncentivesController(
-      [AAVE_STAKE, AAVE_SHORT_EXECUTOR],
+    const incentives = await deployStakedTokenIncentivesController(
+      [STAKED_STARLAY, STARLAY_SHORT_EXECUTOR],
       false, // TODO: revert
       deployer
     );

--- a/test-fork/incentives-skip.spec.ts
+++ b/test-fork/incentives-skip.spec.ts
@@ -34,7 +34,7 @@ import { getUserIndex } from '../test/DistributionManager/data-helpers/asset-use
 import { IERC20DetailedFactory } from '../types/IERC20DetailedFactory';
 import { fullCycleLendingPool, getReserveConfigs, spendList } from './helpers';
 import {
-  deployAaveIncentivesController,
+  deployStakedTokenIncentivesController,
   deployInitializableAdminUpgradeabilityProxy,
 } from '../helpers/contracts-accessors';
 import { withSaveAndVerify } from '../helpers/contracts-helpers';
@@ -49,7 +49,7 @@ const {
   TREASURY = '0x464c71f6c2f760dda6093dcb91c24c39e5d6e18c',
   IPFS_HASH = 'QmT9qk3CRYbFDWpDFYeAv8T8H1gnongwKhh5J68NLkLir6',
   AAVE_GOVERNANCE_V2 = '0xEC568fffba86c094cf06b22134B23074DFE2252c', // mainnet
-  AAVE_SHORT_EXECUTOR = '0xee56e2b3d491590b5b31738cc34d5232f378a8d5', // mainnet
+  STARLAY_SHORT_EXECUTOR = '0xee56e2b3d491590b5b31738cc34d5232f378a8d5', // mainnet
 } = process.env;
 
 if (
@@ -60,7 +60,7 @@ if (
   !AAVE_TOKEN ||
   !IPFS_HASH ||
   !AAVE_GOVERNANCE_V2 ||
-  !AAVE_SHORT_EXECUTOR ||
+  !STARLAY_SHORT_EXECUTOR ||
   !TREASURY
 ) {
   throw new Error('You have not set correctly the .env file, make sure to read the README.md');
@@ -71,7 +71,7 @@ const VOTING_DURATION = 19200;
 
 const AAVE_WHALE = '0x25f2226b597e8f9514b3f68f00f494cf4f286491';
 
-const AAVE_STAKE = '0x4da27a545c0c5B758a6BA100e3a049001de870f5';
+const STAKED_STARLAY = '0x4da27a545c0c5B758a6BA100e3a049001de870f5';
 const DAI_TOKEN = '0x6b175474e89094c44da98b954eedeac495271d0f';
 const DAI_HOLDER = '0x72aabd13090af25dbb804f84de6280c697ed1150';
 
@@ -127,9 +127,9 @@ describe('Enable incentives in target assets', () => {
     [proposer, incentivesProxyAdmin] = await DRE.ethers.getSigners();
 
     // Deploy incentives implementation
-    const { address: incentivesImplementation } = await deployAaveIncentivesController([
-      AAVE_STAKE,
-      AAVE_SHORT_EXECUTOR,
+    const { address: incentivesImplementation } = await deployStakedTokenIncentivesController([
+      STAKED_STARLAY,
+      STARLAY_SHORT_EXECUTOR,
     ]);
     const incentivesInitParams = StakedTokenIncentivesControllerFactory.connect(
       incentivesImplementation,
@@ -207,7 +207,7 @@ describe('Enable incentives in target assets', () => {
     // Send ether to the Short Executor, which is a non payable contract via selfdestruct
     const selfDestructContractV3 = await new SelfdestructTransferFactory(proposer).deploy();
     await (
-      await selfDestructContractV3.destroyAndTransfer(AAVE_SHORT_EXECUTOR, {
+      await selfDestructContractV3.destroyAndTransfer(STARLAY_SHORT_EXECUTOR, {
         value: ethers.utils.parseEther('1'),
       })
     ).wait();
@@ -215,7 +215,7 @@ describe('Enable incentives in target assets', () => {
       AAVE_WHALE,
       ...Object.keys(spendList).map((k) => spendList[k].holder),
       AAVE_GOVERNANCE_V2,
-      AAVE_SHORT_EXECUTOR,
+      STARLAY_SHORT_EXECUTOR,
     ]);
 
     // Impersonating holders
@@ -241,7 +241,7 @@ describe('Enable incentives in target assets', () => {
     } = await pool.getReserveData(DAI_TOKEN);
 
     aave = IERC20Factory.connect(AAVE_TOKEN, whale);
-    stkAave = IERC20Factory.connect(AAVE_STAKE, proposer);
+    stkAave = IERC20Factory.connect(STAKED_STARLAY, proposer);
     dai = IERC20Factory.connect(DAI_TOKEN, daiHolder);
     aDAI = ATokenFactory.connect(aTokenAddress, proposer);
     variableDebtDAI = IERC20Factory.connect(variableDebtTokenAddress, proposer);
@@ -278,7 +278,7 @@ describe('Enable incentives in target assets', () => {
 
   it('Proposal should be executed', async () => {
     const impersonatedGovernance = await ethers.provider.getSigner(AAVE_GOVERNANCE_V2);
-    const impersonateExecutor = await ethers.provider.getSigner(AAVE_SHORT_EXECUTOR);
+    const impersonateExecutor = await ethers.provider.getSigner(STARLAY_SHORT_EXECUTOR);
 
     const executionPayload = ProposalIncentivesExecutorFactory.connect(
       proposalExecutionPayload,

--- a/test-fork/incentivesProposal.spec.ts
+++ b/test-fork/incentivesProposal.spec.ts
@@ -30,7 +30,7 @@ import { getRewards } from '../test/DistributionManager/data-helpers/base-math';
 import { getUserIndex } from '../test/DistributionManager/data-helpers/asset-user-data';
 import { IERC20DetailedFactory } from '../types/IERC20DetailedFactory';
 import { fullCycleLendingPool, getReserveConfigs, spendList } from './helpers';
-import { deployAaveIncentivesController } from '../helpers/contracts-accessors';
+import { deployStakedTokenIncentivesController } from '../helpers/contracts-accessors';
 import { IGovernancePowerDelegationTokenFactory } from '../types/IGovernancePowerDelegationTokenFactory';
 import { logError } from '../helpers/tenderly-utils';
 
@@ -45,7 +45,7 @@ const {
   IPFS_HASH = 'QmT9qk3CRYbFDWpDFYeAv8T8H1gnongwKhh5J68NLkLir6',
   INCENTIVES_PROXY = '0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5',
   AAVE_GOVERNANCE_V2 = '0xEC568fffba86c094cf06b22134B23074DFE2252c', // mainnet
-  AAVE_SHORT_EXECUTOR = '0xee56e2b3d491590b5b31738cc34d5232f378a8d5', // mainnet
+  STARLAY_SHORT_EXECUTOR = '0xee56e2b3d491590b5b31738cc34d5232f378a8d5', // mainnet
 } = process.env;
 
 if (
@@ -56,7 +56,7 @@ if (
   !AAVE_TOKEN ||
   !IPFS_HASH ||
   !AAVE_GOVERNANCE_V2 ||
-  !AAVE_SHORT_EXECUTOR ||
+  !STARLAY_SHORT_EXECUTOR ||
   !TREASURY
 ) {
   throw new Error('You have not set correctly the .env file, make sure to read the README.md');
@@ -67,7 +67,7 @@ const VOTING_DURATION = 19200;
 
 const AAVE_WHALE = '0x25f2226b597e8f9514b3f68f00f494cf4f286491';
 
-const AAVE_STAKE = '0x4da27a545c0c5B758a6BA100e3a049001de870f5';
+const STAKED_STARLAY = '0x4da27a545c0c5B758a6BA100e3a049001de870f5';
 const DAI_TOKEN = '0x6b175474e89094c44da98b954eedeac495271d0f';
 const DAI_HOLDER = '0x72aabd13090af25dbb804f84de6280c697ed1150';
 
@@ -103,9 +103,9 @@ describe('Enable incentives in target assets', () => {
     [proposer, incentivesProxyAdmin] = await DRE.ethers.getSigners();
 
     // Deploy incentives implementation
-    const { address: incentivesImplementation } = await deployAaveIncentivesController([
-      AAVE_STAKE,
-      AAVE_SHORT_EXECUTOR,
+    const { address: incentivesImplementation } = await deployStakedTokenIncentivesController([
+      STAKED_STARLAY,
+      STARLAY_SHORT_EXECUTOR,
     ]);
 
     incentivesProxy = INCENTIVES_PROXY;
@@ -161,7 +161,7 @@ describe('Enable incentives in target assets', () => {
     } = await pool.getReserveData(DAI_TOKEN);
 
     aave = IERC20Factory.connect(AAVE_TOKEN, whale);
-    stkAave = IERC20Factory.connect(AAVE_STAKE, proposer);
+    stkAave = IERC20Factory.connect(STAKED_STARLAY, proposer);
     dai = IERC20Factory.connect(DAI_TOKEN, daiHolder);
     aDAI = ATokenFactory.connect(aTokenAddress, proposer);
     variableDebtDAI = IERC20Factory.connect(variableDebtTokenAddress, proposer);

--- a/test/PullRewardsIncentivesController/claim-on-behalf.spec.ts
+++ b/test/PullRewardsIncentivesController/claim-on-behalf.spec.ts
@@ -15,7 +15,7 @@ makeSuite('PullRewardsIncentivesController - Claim rewards on behalf', (testEnv:
     ).to.be.revertedWith('ONLY_EMISSION_MANAGER');
   });
   it('Should claimRewardsOnBehalf revert if called claimer is not authorized', async () => {
-    const { pullRewardsIncentivesController, users, aDaiBaseMock, aaveToken } = testEnv;
+    const { pullRewardsIncentivesController, users, aDaiBaseMock, token } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
     await waitForTx(
@@ -24,7 +24,7 @@ makeSuite('PullRewardsIncentivesController - Claim rewards on behalf', (testEnv:
     await waitForTx(await aDaiBaseMock.setUserBalanceAndSupply('300000', '300000'));
 
     // Claim from third party claimer
-    const priorStkBalance = await aaveToken.balanceOf(thirdClaimer.address);
+    const priorStkBalance = await token.balanceOf(thirdClaimer.address);
 
     await expect(
       pullRewardsIncentivesController
@@ -37,7 +37,7 @@ makeSuite('PullRewardsIncentivesController - Claim rewards on behalf', (testEnv:
         )
     ).to.be.revertedWith('CLAIMER_UNAUTHORIZED');
 
-    const afterStkBalance = await aaveToken.balanceOf(thirdClaimer.address);
+    const afterStkBalance = await token.balanceOf(thirdClaimer.address);
     expect(afterStkBalance).to.be.eq(priorStkBalance);
   });
   it('Should setClaimer pass if called by emission manager', async () => {
@@ -57,7 +57,7 @@ makeSuite('PullRewardsIncentivesController - Claim rewards on behalf', (testEnv:
     ).to.be.equal(thirdClaimer.address);
   });
   it('Should claimRewardsOnBehalf pass if called by the assigned claimer', async () => {
-    const { pullRewardsIncentivesController, users, aDaiBaseMock, aaveToken } = testEnv;
+    const { pullRewardsIncentivesController, users, aDaiBaseMock, token } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
     await waitForTx(
@@ -66,7 +66,7 @@ makeSuite('PullRewardsIncentivesController - Claim rewards on behalf', (testEnv:
     await waitForTx(await aDaiBaseMock.setUserBalanceAndSupply('300000', '30000'));
 
     // Claim from third party claimer
-    const priorBalance = await aaveToken.balanceOf(thirdClaimer.address);
+    const priorBalance = await token.balanceOf(thirdClaimer.address);
 
     await expect(
       pullRewardsIncentivesController
@@ -80,12 +80,12 @@ makeSuite('PullRewardsIncentivesController - Claim rewards on behalf', (testEnv:
     )
       .to.emit(pullRewardsIncentivesController, 'RewardsClaimed')
       .withArgs(userWithRewards.address, thirdClaimer.address, thirdClaimer.address, '99999');
-    const afterStkBalance = await aaveToken.balanceOf(thirdClaimer.address);
+    const afterStkBalance = await token.balanceOf(thirdClaimer.address);
     expect(afterStkBalance).to.be.gt(priorBalance);
   });
 
   it('Should claimRewardsOnBehalf revert if to argument address is ZERO_ADDRESS', async () => {
-    const { pullRewardsIncentivesController, users, aDaiBaseMock, aaveToken } = testEnv;
+    const { pullRewardsIncentivesController, users, aDaiBaseMock } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
     await waitForTx(

--- a/test/PullRewardsIncentivesController/claim-rewards-to-self.spec.ts
+++ b/test/PullRewardsIncentivesController/claim-rewards-to-self.spec.ts
@@ -55,7 +55,7 @@ makeSuite('pullRewardsIncentivesController claimRewardsToSelf tests', (testEnv) 
     let amountToClaim = _amountToClaim;
     it(caseName, async () => {
       await increaseTime(100);
-      const { pullRewardsIncentivesController, aaveToken, aDaiBaseMock } = testEnv;
+      const { pullRewardsIncentivesController, token, aDaiBaseMock } = testEnv;
 
       const distributionEndTimestamp = await pullRewardsIncentivesController.getDistributionEnd();
       const userAddress = await pullRewardsIncentivesController.signer.getAddress();
@@ -74,7 +74,7 @@ makeSuite('pullRewardsIncentivesController claimRewardsToSelf tests', (testEnv) 
 
       const destinationAddress = userAddress;
 
-      const destinationAddressBalanceBefore = await aaveToken.balanceOf(destinationAddress);
+      const destinationAddressBalanceBefore = await token.balanceOf(destinationAddress);
       await aDaiBaseMock.setUserBalanceAndSupply(stakedByUser, totalStaked);
       await aDaiBaseMock.handleActionOnAic(userAddress, totalStaked, stakedByUser);
 
@@ -113,7 +113,7 @@ makeSuite('pullRewardsIncentivesController claimRewardsToSelf tests', (testEnv) 
         userAddress
       );
 
-      const destinationAddressBalanceAfter = await aaveToken.balanceOf(destinationAddress);
+      const destinationAddressBalanceAfter = await token.balanceOf(destinationAddress);
 
       const claimedAmount = destinationAddressBalanceAfter.sub(destinationAddressBalanceBefore);
 

--- a/test/PullRewardsIncentivesController/claim-rewards.spec.ts
+++ b/test/PullRewardsIncentivesController/claim-rewards.spec.ts
@@ -70,7 +70,7 @@ makeSuite('pullRewardsIncentivesController claimRewards tests', (testEnv) => {
     let amountToClaim = _amountToClaim;
     it(caseName, async () => {
       await increaseTime(100);
-      const { pullRewardsIncentivesController, aaveToken, aDaiBaseMock } = testEnv;
+      const { pullRewardsIncentivesController, token, aDaiBaseMock } = testEnv;
 
       const distributionEndTimestamp = await pullRewardsIncentivesController.getDistributionEnd();
       const userAddress = await pullRewardsIncentivesController.signer.getAddress();
@@ -89,7 +89,7 @@ makeSuite('pullRewardsIncentivesController claimRewards tests', (testEnv) => {
 
       const destinationAddress = to || userAddress;
 
-      const destinationAddressBalanceBefore = await aaveToken.balanceOf(destinationAddress);
+      const destinationAddressBalanceBefore = await token.balanceOf(destinationAddress);
       await aDaiBaseMock.setUserBalanceAndSupply(stakedByUser, totalStaked);
       await aDaiBaseMock.handleActionOnAic(userAddress, totalStaked, stakedByUser);
 
@@ -132,7 +132,7 @@ makeSuite('pullRewardsIncentivesController claimRewards tests', (testEnv) => {
         userAddress
       );
 
-      const destinationAddressBalanceAfter = await aaveToken.balanceOf(destinationAddress);
+      const destinationAddressBalanceAfter = await token.balanceOf(destinationAddress);
 
       const claimedAmount = destinationAddressBalanceAfter.sub(destinationAddressBalanceBefore);
 

--- a/test/PullRewardsIncentivesController/misc.spec.ts
+++ b/test/PullRewardsIncentivesController/misc.spec.ts
@@ -58,9 +58,9 @@ makeSuite('pullRewardsIncentivesController misc tests', (testEnv) => {
   });
 
   it('Should REWARD_TOKEN getter returns the stake token address to keep old interface compatibility', async () => {
-    const { pullRewardsIncentivesController, aaveToken } = testEnv;
+    const { pullRewardsIncentivesController, token } = testEnv;
     await expect(await pullRewardsIncentivesController.REWARD_TOKEN()).to.be.equal(
-      aaveToken.address
+      token.address
     );
   });
 

--- a/test/StakedIncentivesController/claim-on-behalf.spec.ts
+++ b/test/StakedIncentivesController/claim-on-behalf.spec.ts
@@ -6,26 +6,26 @@ import { makeSuite, TestEnv } from '../helpers/make-suite';
 
 makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEnv) => {
   it('Should setClaimer revert if not called by emission manager', async () => {
-    const { aaveIncentivesController, users } = testEnv;
+    const { incentivesController, users } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(userWithRewards.signer)
         .setClaimer(userWithRewards.address, thirdClaimer.address)
     ).to.be.revertedWith('ONLY_EMISSION_MANAGER');
   });
   it('Should claimRewardsOnBehalf revert if called claimer is not authorized', async () => {
-    const { aaveIncentivesController, users, aDaiMock, stakedToken } = testEnv;
+    const { incentivesController, users, aDaiMock, stakedToken } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
-    await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));
+    await waitForTx(await incentivesController.configureAssets([aDaiMock.address], ['2000']));
     await waitForTx(await aDaiMock.setUserBalanceAndSupply('300000', '30000'));
 
     // Claim from third party claimer
     const priorStkBalance = await stakedToken.balanceOf(thirdClaimer.address);
 
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(thirdClaimer.signer)
         .claimRewardsOnBehalf(
           [aDaiMock.address],
@@ -39,33 +39,33 @@ makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEn
     expect(afterStkBalance).to.be.eq(priorStkBalance);
   });
   it('Should setClaimer pass if called by emission manager', async () => {
-    const { aaveIncentivesController, users, rewardsVault } = testEnv;
+    const { incentivesController, users, rewardsVault } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
     const emissionManager = rewardsVault;
 
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(emissionManager.signer)
         .setClaimer(userWithRewards.address, thirdClaimer.address)
     )
-      .to.emit(aaveIncentivesController, 'ClaimerSet')
+      .to.emit(incentivesController, 'ClaimerSet')
       .withArgs(userWithRewards.address, thirdClaimer.address);
-    await expect(await aaveIncentivesController.getClaimer(userWithRewards.address)).to.be.equal(
+    await expect(await incentivesController.getClaimer(userWithRewards.address)).to.be.equal(
       thirdClaimer.address
     );
   });
   it('Should claimRewardsOnBehalf pass if called by the assigned claimer', async () => {
-    const { aaveIncentivesController, users, aDaiMock, stakedToken } = testEnv;
+    const { incentivesController, users, aDaiMock, stakedToken } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
-    await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));
+    await waitForTx(await incentivesController.configureAssets([aDaiMock.address], ['2000']));
     await waitForTx(await aDaiMock.setUserBalanceAndSupply('300000', '30000'));
 
     // Claim from third party claimer
     const priorStkBalance = await stakedToken.balanceOf(thirdClaimer.address);
 
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(thirdClaimer.signer)
         .claimRewardsOnBehalf(
           [aDaiMock.address],
@@ -74,21 +74,21 @@ makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEn
           thirdClaimer.address
         )
     )
-      .to.emit(aaveIncentivesController, 'RewardsClaimed')
+      .to.emit(incentivesController, 'RewardsClaimed')
       .withArgs(userWithRewards.address, thirdClaimer.address, thirdClaimer.address, '99999');
     const afterStkBalance = await stakedToken.balanceOf(thirdClaimer.address);
     expect(afterStkBalance).to.be.gt(priorStkBalance);
   });
 
   it('Should claimRewardsOnBehalf revert if to argument address is ZERO_ADDRESS', async () => {
-    const { aaveIncentivesController, users, aDaiMock, stakedToken } = testEnv;
+    const { incentivesController, users, aDaiMock, stakedToken } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
-    await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));
+    await waitForTx(await incentivesController.configureAssets([aDaiMock.address], ['2000']));
     await waitForTx(await aDaiMock.setUserBalanceAndSupply('300000', '30000'));
 
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(thirdClaimer.signer)
         .claimRewardsOnBehalf(
           [aDaiMock.address],
@@ -100,24 +100,24 @@ makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEn
   });
 
   it('Should claimRewardsOnBehalf revert if user argument is ZERO_ADDRESS', async () => {
-    const { aaveIncentivesController, users, aDaiMock, rewardsVault } = testEnv;
+    const { incentivesController, users, aDaiMock, rewardsVault } = testEnv;
     const [, thirdClaimer] = users;
 
     const emissionManager = rewardsVault;
 
-    await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));
+    await waitForTx(await incentivesController.configureAssets([aDaiMock.address], ['2000']));
     await waitForTx(await aDaiMock.setUserBalanceAndSupply('300000', '30000'));
 
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(emissionManager.signer)
         .setClaimer(ZERO_ADDRESS, thirdClaimer.address)
     )
-      .to.emit(aaveIncentivesController, 'ClaimerSet')
+      .to.emit(incentivesController, 'ClaimerSet')
       .withArgs(ZERO_ADDRESS, thirdClaimer.address);
 
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(thirdClaimer.signer)
         .claimRewardsOnBehalf(
           [aDaiMock.address],

--- a/test/StakedIncentivesController/claim-on-behalf.spec.ts
+++ b/test/StakedIncentivesController/claim-on-behalf.spec.ts
@@ -15,14 +15,14 @@ makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEn
     ).to.be.revertedWith('ONLY_EMISSION_MANAGER');
   });
   it('Should claimRewardsOnBehalf revert if called claimer is not authorized', async () => {
-    const { aaveIncentivesController, users, aDaiMock, stakedAave } = testEnv;
+    const { aaveIncentivesController, users, aDaiMock, stakedToken } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
     await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));
     await waitForTx(await aDaiMock.setUserBalanceAndSupply('300000', '30000'));
 
     // Claim from third party claimer
-    const priorStkBalance = await stakedAave.balanceOf(thirdClaimer.address);
+    const priorStkBalance = await stakedToken.balanceOf(thirdClaimer.address);
 
     await expect(
       aaveIncentivesController
@@ -35,7 +35,7 @@ makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEn
         )
     ).to.be.revertedWith('CLAIMER_UNAUTHORIZED');
 
-    const afterStkBalance = await stakedAave.balanceOf(thirdClaimer.address);
+    const afterStkBalance = await stakedToken.balanceOf(thirdClaimer.address);
     expect(afterStkBalance).to.be.eq(priorStkBalance);
   });
   it('Should setClaimer pass if called by emission manager', async () => {
@@ -55,14 +55,14 @@ makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEn
     );
   });
   it('Should claimRewardsOnBehalf pass if called by the assigned claimer', async () => {
-    const { aaveIncentivesController, users, aDaiMock, stakedAave } = testEnv;
+    const { aaveIncentivesController, users, aDaiMock, stakedToken } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
     await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));
     await waitForTx(await aDaiMock.setUserBalanceAndSupply('300000', '30000'));
 
     // Claim from third party claimer
-    const priorStkBalance = await stakedAave.balanceOf(thirdClaimer.address);
+    const priorStkBalance = await stakedToken.balanceOf(thirdClaimer.address);
 
     await expect(
       aaveIncentivesController
@@ -76,12 +76,12 @@ makeSuite('AaveIncentivesController - Claim rewards on behalf', (testEnv: TestEn
     )
       .to.emit(aaveIncentivesController, 'RewardsClaimed')
       .withArgs(userWithRewards.address, thirdClaimer.address, thirdClaimer.address, '99999');
-    const afterStkBalance = await stakedAave.balanceOf(thirdClaimer.address);
+    const afterStkBalance = await stakedToken.balanceOf(thirdClaimer.address);
     expect(afterStkBalance).to.be.gt(priorStkBalance);
   });
 
   it('Should claimRewardsOnBehalf revert if to argument address is ZERO_ADDRESS', async () => {
-    const { aaveIncentivesController, users, aDaiMock, stakedAave } = testEnv;
+    const { aaveIncentivesController, users, aDaiMock, stakedToken } = testEnv;
     const [userWithRewards, thirdClaimer] = users;
 
     await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));

--- a/test/StakedIncentivesController/claim-rewards-to-self.spec.ts
+++ b/test/StakedIncentivesController/claim-rewards-to-self.spec.ts
@@ -55,10 +55,10 @@ makeSuite('AaveIncentivesController claimRewardsToSelf tests', (testEnv) => {
     let amountToClaim = _amountToClaim;
     it(caseName, async () => {
       await increaseTime(100);
-      const { aaveIncentivesController, stakedToken, aDaiMock } = testEnv;
+      const { incentivesController, stakedToken, aDaiMock } = testEnv;
 
-      const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
-      const userAddress = await aaveIncentivesController.signer.getAddress();
+      const distributionEndTimestamp = await incentivesController.getDistributionEnd();
+      const userAddress = await incentivesController.signer.getAddress();
 
       const underlyingAsset = aDaiMock.address;
       const stakedByUser = 22 * caseName.length;
@@ -66,7 +66,7 @@ makeSuite('AaveIncentivesController claimRewardsToSelf tests', (testEnv) => {
 
       // update emissionPerSecond in advance to not affect user calculations
       if (emissionPerSecond) {
-        await aaveIncentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
+        await incentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
       }
 
       const destinationAddress = userAddress;
@@ -75,32 +75,32 @@ makeSuite('AaveIncentivesController claimRewardsToSelf tests', (testEnv) => {
       await aDaiMock.setUserBalanceAndSupply(stakedByUser, totalStaked);
       await aDaiMock.handleActionOnAic(userAddress, totalStaked, stakedByUser);
 
-      const unclaimedRewardsBefore = await aaveIncentivesController.getRewardsBalance(
+      const unclaimedRewardsBefore = await incentivesController.getRewardsBalance(
         [underlyingAsset],
         userAddress
       );
       const userIndexBefore = await getUserIndex(
-        aaveIncentivesController,
+        incentivesController,
         userAddress,
         underlyingAsset
       );
-      const assetDataBefore = (await getAssetsData(aaveIncentivesController, [underlyingAsset]))[0];
+      const assetDataBefore = (await getAssetsData(incentivesController, [underlyingAsset]))[0];
 
       const claimRewardsToSelfReceipt = await waitForTx(
-        await aaveIncentivesController.claimRewardsToSelf([underlyingAsset], amountToClaim)
+        await incentivesController.claimRewardsToSelf([underlyingAsset], amountToClaim)
       );
       const eventsEmitted = claimRewardsToSelfReceipt.events || [];
 
       const actionBlockTimestamp = await getBlockTimestamp(claimRewardsToSelfReceipt.blockNumber);
 
       const userIndexAfter = await getUserIndex(
-        aaveIncentivesController,
+        incentivesController,
         userAddress,
         underlyingAsset
       );
-      const assetDataAfter = (await getAssetsData(aaveIncentivesController, [underlyingAsset]))[0];
+      const assetDataAfter = (await getAssetsData(incentivesController, [underlyingAsset]))[0];
 
-      const unclaimedRewardsAfter = await aaveIncentivesController.getRewardsBalance(
+      const unclaimedRewardsAfter = await incentivesController.getRewardsBalance(
         [underlyingAsset],
         userAddress
       );

--- a/test/StakedIncentivesController/claim-rewards-to-self.spec.ts
+++ b/test/StakedIncentivesController/claim-rewards-to-self.spec.ts
@@ -55,7 +55,7 @@ makeSuite('AaveIncentivesController claimRewardsToSelf tests', (testEnv) => {
     let amountToClaim = _amountToClaim;
     it(caseName, async () => {
       await increaseTime(100);
-      const { aaveIncentivesController, stakedAave, aDaiMock } = testEnv;
+      const { aaveIncentivesController, stakedToken, aDaiMock } = testEnv;
 
       const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
       const userAddress = await aaveIncentivesController.signer.getAddress();
@@ -71,7 +71,7 @@ makeSuite('AaveIncentivesController claimRewardsToSelf tests', (testEnv) => {
 
       const destinationAddress = userAddress;
 
-      const destinationAddressBalanceBefore = await stakedAave.balanceOf(destinationAddress);
+      const destinationAddressBalanceBefore = await stakedToken.balanceOf(destinationAddress);
       await aDaiMock.setUserBalanceAndSupply(stakedByUser, totalStaked);
       await aDaiMock.handleActionOnAic(userAddress, totalStaked, stakedByUser);
 
@@ -105,7 +105,7 @@ makeSuite('AaveIncentivesController claimRewardsToSelf tests', (testEnv) => {
         userAddress
       );
 
-      const destinationAddressBalanceAfter = await stakedAave.balanceOf(destinationAddress);
+      const destinationAddressBalanceAfter = await stakedToken.balanceOf(destinationAddress);
 
       const claimedAmount = destinationAddressBalanceAfter.sub(destinationAddressBalanceBefore);
 

--- a/test/StakedIncentivesController/claim-rewards.spec.ts
+++ b/test/StakedIncentivesController/claim-rewards.spec.ts
@@ -70,7 +70,7 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
     let amountToClaim = _amountToClaim;
     it(caseName, async () => {
       await increaseTime(100);
-      const { aaveIncentivesController, stakedAave, aDaiMock } = testEnv;
+      const { aaveIncentivesController, stakedToken, aDaiMock } = testEnv;
 
       const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
       const userAddress = await aaveIncentivesController.signer.getAddress();
@@ -86,7 +86,7 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
 
       const destinationAddress = to || userAddress;
 
-      const destinationAddressBalanceBefore = await stakedAave.balanceOf(destinationAddress);
+      const destinationAddressBalanceBefore = await stakedToken.balanceOf(destinationAddress);
       await aDaiMock.setUserBalanceAndSupply(stakedByUser, totalStaked);
       await aDaiMock.handleActionOnAic(userAddress, totalStaked, stakedByUser);
 
@@ -124,7 +124,7 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
         userAddress
       );
 
-      const destinationAddressBalanceAfter = await stakedAave.balanceOf(destinationAddress);
+      const destinationAddressBalanceAfter = await stakedToken.balanceOf(destinationAddress);
 
       const claimedAmount = destinationAddressBalanceAfter.sub(destinationAddressBalanceBefore);
 

--- a/test/StakedIncentivesController/claim-rewards.spec.ts
+++ b/test/StakedIncentivesController/claim-rewards.spec.ts
@@ -70,10 +70,10 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
     let amountToClaim = _amountToClaim;
     it(caseName, async () => {
       await increaseTime(100);
-      const { aaveIncentivesController, stakedToken, aDaiMock } = testEnv;
+      const { incentivesController, stakedToken, aDaiMock } = testEnv;
 
-      const distributionEndTimestamp = await aaveIncentivesController.getDistributionEnd();
-      const userAddress = await aaveIncentivesController.signer.getAddress();
+      const distributionEndTimestamp = await incentivesController.getDistributionEnd();
+      const userAddress = await incentivesController.signer.getAddress();
 
       const underlyingAsset = aDaiMock.address;
       const stakedByUser = 22 * caseName.length;
@@ -81,7 +81,7 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
 
       // update emissionPerSecond in advance to not affect user calculations
       if (emissionPerSecond) {
-        await aaveIncentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
+        await incentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
       }
 
       const destinationAddress = to || userAddress;
@@ -90,19 +90,19 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
       await aDaiMock.setUserBalanceAndSupply(stakedByUser, totalStaked);
       await aDaiMock.handleActionOnAic(userAddress, totalStaked, stakedByUser);
 
-      const unclaimedRewardsBefore = await aaveIncentivesController.getRewardsBalance(
+      const unclaimedRewardsBefore = await incentivesController.getRewardsBalance(
         [underlyingAsset],
         userAddress
       );
       const userIndexBefore = await getUserIndex(
-        aaveIncentivesController,
+        incentivesController,
         userAddress,
         underlyingAsset
       );
-      const assetDataBefore = (await getAssetsData(aaveIncentivesController, [underlyingAsset]))[0];
+      const assetDataBefore = (await getAssetsData(incentivesController, [underlyingAsset]))[0];
 
       const claimRewardsReceipt = await waitForTx(
-        await aaveIncentivesController.claimRewards(
+        await incentivesController.claimRewards(
           [underlyingAsset],
           amountToClaim,
           destinationAddress
@@ -113,13 +113,13 @@ makeSuite('AaveIncentivesController claimRewards tests', (testEnv) => {
       const actionBlockTimestamp = await getBlockTimestamp(claimRewardsReceipt.blockNumber);
 
       const userIndexAfter = await getUserIndex(
-        aaveIncentivesController,
+        incentivesController,
         userAddress,
         underlyingAsset
       );
-      const assetDataAfter = (await getAssetsData(aaveIncentivesController, [underlyingAsset]))[0];
+      const assetDataAfter = (await getAssetsData(incentivesController, [underlyingAsset]))[0];
 
-      const unclaimedRewardsAfter = await aaveIncentivesController.getRewardsBalance(
+      const unclaimedRewardsAfter = await incentivesController.getRewardsBalance(
         [underlyingAsset],
         userAddress
       );

--- a/test/StakedIncentivesController/configure-assets.spec.ts
+++ b/test/StakedIncentivesController/configure-assets.spec.ts
@@ -127,9 +127,9 @@ makeSuite('AaveIncentivesController configureAssets', (testEnv: TestEnv) => {
 
   // custom checks
   it('Tries to submit config updates not from emission manager', async () => {
-    const { aaveIncentivesController, users } = testEnv;
+    const { incentivesController, users } = testEnv;
     await expect(
-      aaveIncentivesController.connect(users[2].signer).configureAssets([], [])
+      incentivesController.connect(users[2].signer).configureAssets([], [])
     ).to.be.revertedWith('ONLY_EMISSION_MANAGER');
   });
 
@@ -140,8 +140,8 @@ makeSuite('AaveIncentivesController configureAssets', (testEnv: TestEnv) => {
     customTimeMovement,
   } of configureAssetScenarios) {
     it(caseName, async () => {
-      const { aaveIncentivesController } = testEnv;
-      const distributionEndTimestamp = await aaveIncentivesController.DISTRIBUTION_END();
+      const { incentivesController } = testEnv;
+      const distributionEndTimestamp = await incentivesController.DISTRIBUTION_END();
 
       const assets: string[] = [];
       const assetsEmissions: BigNumberish[] = [];
@@ -166,17 +166,17 @@ makeSuite('AaveIncentivesController configureAssets', (testEnv: TestEnv) => {
         });
       }
 
-      const assetsConfigBefore = await getAssetsData(aaveIncentivesController, assets);
+      const assetsConfigBefore = await getAssetsData(incentivesController, assets);
 
       if (customTimeMovement) {
         await increaseTime(customTimeMovement);
       }
 
       const txReceipt = await waitForTx(
-        await aaveIncentivesController.configureAssets(assets, assetsEmissions)
+        await incentivesController.configureAssets(assets, assetsEmissions)
       );
       const configsUpdateBlockTimestamp = await getBlockTimestamp(txReceipt.blockNumber);
-      const assetsConfigAfter = await getAssetsData(aaveIncentivesController, assets);
+      const assetsConfigAfter = await getAssetsData(incentivesController, assets);
 
       const eventsEmitted = txReceipt.events || [];
 

--- a/test/StakedIncentivesController/get-rewards-balance.spec.ts
+++ b/test/StakedIncentivesController/get-rewards-balance.spec.ts
@@ -33,9 +33,9 @@ makeSuite('AaveIncentivesController getRewardsBalance tests', (testEnv) => {
     it(caseName, async () => {
       await increaseTime(100);
 
-      const { aaveIncentivesController, users, aDaiMock } = testEnv;
+      const { incentivesController, users, aDaiMock } = testEnv;
 
-      const distributionEndTimestamp = await aaveIncentivesController.DISTRIBUTION_END();
+      const distributionEndTimestamp = await incentivesController.DISTRIBUTION_END();
       const userAddress = users[1].address;
       const stakedByUser = 22 * caseName.length;
       const totalStaked = 33 * caseName.length;
@@ -45,7 +45,7 @@ makeSuite('AaveIncentivesController getRewardsBalance tests', (testEnv) => {
       await advanceBlock((await timeLatest()).plus(100).toNumber());
       if (emissionPerSecond) {
         await aDaiMock.setUserBalanceAndSupply('0', totalStaked);
-        await aaveIncentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
+        await incentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
       }
       await aDaiMock.handleActionOnAic(userAddress, totalStaked, stakedByUser);
       await advanceBlock((await timeLatest()).plus(100).toNumber());
@@ -55,17 +55,17 @@ makeSuite('AaveIncentivesController getRewardsBalance tests', (testEnv) => {
       );
       const lastTxTimestamp = await getBlockTimestamp(lastTxReceipt.blockNumber);
 
-      const unclaimedRewardsBefore = await aaveIncentivesController.getUserUnclaimedRewards(
+      const unclaimedRewardsBefore = await incentivesController.getUserUnclaimedRewards(
         userAddress
       );
 
-      const unclaimedRewards = await aaveIncentivesController.getRewardsBalance(
+      const unclaimedRewards = await incentivesController.getRewardsBalance(
         [underlyingAsset],
         userAddress
       );
 
-      const userIndex = await getUserIndex(aaveIncentivesController, userAddress, underlyingAsset);
-      const assetData = (await getAssetsData(aaveIncentivesController, [underlyingAsset]))[0];
+      const userIndex = await getUserIndex(incentivesController, userAddress, underlyingAsset);
+      const assetData = (await getAssetsData(incentivesController, [underlyingAsset]))[0];
 
       await aDaiMock.cleanUserState();
 

--- a/test/StakedIncentivesController/handle-action.spec.ts
+++ b/test/StakedIncentivesController/handle-action.spec.ts
@@ -61,26 +61,26 @@ makeSuite('AaveIncentivesController handleAction tests', (testEnv) => {
     it(caseName, async () => {
       await increaseTime(100);
 
-      const { aaveIncentivesController, users, aDaiMock } = testEnv;
+      const { incentivesController, users, aDaiMock } = testEnv;
       const userAddress = users[1].address;
       const underlyingAsset = aDaiMock.address;
 
       // update emissionPerSecond in advance to not affect user calculations
       if (emissionPerSecond) {
-        await aaveIncentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
+        await incentivesController.configureAssets([underlyingAsset], [emissionPerSecond]);
       }
 
-      const distributionEndTimestamp = await aaveIncentivesController.DISTRIBUTION_END();
+      const distributionEndTimestamp = await incentivesController.DISTRIBUTION_END();
 
-      const rewardsBalanceBefore = await aaveIncentivesController.getUserUnclaimedRewards(
+      const rewardsBalanceBefore = await incentivesController.getUserUnclaimedRewards(
         userAddress
       );
       const userIndexBefore = await getUserIndex(
-        aaveIncentivesController,
+        incentivesController,
         userAddress,
         underlyingAsset
       );
-      const assetDataBefore = (await getAssetsData(aaveIncentivesController, [underlyingAsset]))[0];
+      const assetDataBefore = (await getAssetsData(incentivesController, [underlyingAsset]))[0];
 
       if (customTimeMovement) {
         await increaseTime(customTimeMovement);
@@ -94,12 +94,12 @@ makeSuite('AaveIncentivesController handleAction tests', (testEnv) => {
       const actionBlockTimestamp = await getBlockTimestamp(handleActionReceipt.blockNumber);
 
       const userIndexAfter = await getUserIndex(
-        aaveIncentivesController,
+        incentivesController,
         userAddress,
         underlyingAsset
       );
 
-      const assetDataAfter = (await getAssetsData(aaveIncentivesController, [underlyingAsset]))[0];
+      const assetDataAfter = (await getAssetsData(incentivesController, [underlyingAsset]))[0];
 
       const expectedAccruedRewards = getRewards(
         userBalance,
@@ -107,7 +107,7 @@ makeSuite('AaveIncentivesController handleAction tests', (testEnv) => {
         userIndexBefore
       ).toString();
 
-      const rewardsBalanceAfter = await aaveIncentivesController.getUserUnclaimedRewards(
+      const rewardsBalanceAfter = await incentivesController.getUserUnclaimedRewards(
         userAddress
       );
 

--- a/test/StakedIncentivesController/initialize.spec.ts
+++ b/test/StakedIncentivesController/initialize.spec.ts
@@ -6,13 +6,13 @@ const { expect } = require('chai');
 makeSuite('AaveIncentivesController initialize', (testEnv: TestEnv) => {
   // TODO: useless or not?
   it('Tries to call initialize second time, should be reverted', async () => {
-    const { aaveIncentivesController } = testEnv;
-    await expect(aaveIncentivesController.initialize()).to.be.reverted;
+    const { incentivesController } = testEnv;
+    await expect(incentivesController.initialize()).to.be.reverted;
   });
   it('allowance on aave token should be granted to psm contract for pei', async () => {
-    const { aaveIncentivesController, stakedToken, token } = testEnv;
+    const { incentivesController, stakedToken, token } = testEnv;
     await expect(
-      (await token.allowance(aaveIncentivesController.address, stakedToken.address)).toString()
+      (await token.allowance(incentivesController.address, stakedToken.address)).toString()
     ).to.be.equal(MAX_UINT_AMOUNT);
   });
 });

--- a/test/StakedIncentivesController/initialize.spec.ts
+++ b/test/StakedIncentivesController/initialize.spec.ts
@@ -10,9 +10,9 @@ makeSuite('AaveIncentivesController initialize', (testEnv: TestEnv) => {
     await expect(aaveIncentivesController.initialize()).to.be.reverted;
   });
   it('allowance on aave token should be granted to psm contract for pei', async () => {
-    const { aaveIncentivesController, stakedAave, aaveToken } = testEnv;
+    const { aaveIncentivesController, stakedToken, token } = testEnv;
     await expect(
-      (await aaveToken.allowance(aaveIncentivesController.address, stakedAave.address)).toString()
+      (await token.allowance(aaveIncentivesController.address, stakedToken.address)).toString()
     ).to.be.equal(MAX_UINT_AMOUNT);
   });
 });

--- a/test/StakedIncentivesController/misc.spec.ts
+++ b/test/StakedIncentivesController/misc.spec.ts
@@ -56,12 +56,12 @@ makeSuite('AaveIncentivesController misc tests', (testEnv) => {
   });
 
   it('Should REWARD_TOKEN getter returns the stake token address to keep old interface compatibility', async () => {
-    const { aaveIncentivesController, stakedAave } = testEnv;
-    await expect(await aaveIncentivesController.REWARD_TOKEN()).to.be.equal(stakedAave.address);
+    const { aaveIncentivesController, stakedToken } = testEnv;
+    await expect(await aaveIncentivesController.REWARD_TOKEN()).to.be.equal(stakedToken.address);
   });
 
   it('Should claimRewards revert if to argument is ZERO_ADDRESS', async () => {
-    const { aaveIncentivesController, users, aDaiMock, stakedAave } = testEnv;
+    const { aaveIncentivesController, users, aDaiMock } = testEnv;
     const [userWithRewards] = users;
 
     await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));

--- a/test/StakedIncentivesController/misc.spec.ts
+++ b/test/StakedIncentivesController/misc.spec.ts
@@ -11,28 +11,28 @@ makeSuite('AaveIncentivesController misc tests', (testEnv) => {
     const peiEmissionManager = RANDOM_ADDRESSES[1];
     const psm = RANDOM_ADDRESSES[5];
 
-    const aaveIncentivesController = await deployAaveIncentivesController([
+    const incentivesController = await deployAaveIncentivesController([
       psm,
       peiEmissionManager,
     ]);
-    await expect(await aaveIncentivesController.STAKE_TOKEN()).to.be.equal(psm);
-    await expect((await aaveIncentivesController.EMISSION_MANAGER()).toString()).to.be.equal(
+    await expect(await incentivesController.STAKE_TOKEN()).to.be.equal(psm);
+    await expect((await incentivesController.EMISSION_MANAGER()).toString()).to.be.equal(
       peiEmissionManager
     );
   });
 
   it('Should return same index while multiple asset index updates', async () => {
-    const { aDaiMock, aaveIncentivesController, users } = testEnv;
-    await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['100']));
+    const { aDaiMock, incentivesController, users } = testEnv;
+    await waitForTx(await incentivesController.configureAssets([aDaiMock.address], ['100']));
     await waitForTx(await aDaiMock.doubleHandleActionOnAic(users[1].address, '2000', '100'));
   });
 
   it('Should overflow index if passed a large emission', async () => {
-    const { aDaiMock, aaveIncentivesController, users } = testEnv;
+    const { aDaiMock, incentivesController, users } = testEnv;
     const MAX_104_UINT = '20282409603651670423947251286015';
 
     await waitForTx(
-      await aaveIncentivesController.configureAssets([aDaiMock.address], [MAX_104_UINT])
+      await incentivesController.configureAssets([aDaiMock.address], [MAX_104_UINT])
     );
     await expect(
       aDaiMock.doubleHandleActionOnAic(users[1].address, '2000', '100')
@@ -40,36 +40,36 @@ makeSuite('AaveIncentivesController misc tests', (testEnv) => {
   });
 
   it('Should configureAssets revert if parameters length does not match', async () => {
-    const { aDaiMock, aaveIncentivesController } = testEnv;
+    const { aDaiMock, incentivesController } = testEnv;
 
     await expect(
-      aaveIncentivesController.configureAssets([aDaiMock.address], ['1', '2'])
+      incentivesController.configureAssets([aDaiMock.address], ['1', '2'])
     ).to.be.revertedWith('INVALID_CONFIGURATION');
   });
 
   it('Should configureAssets revert if emission parameter overflows uin104', async () => {
-    const { aDaiMock, aaveIncentivesController } = testEnv;
+    const { aDaiMock, incentivesController } = testEnv;
 
     await expect(
-      aaveIncentivesController.configureAssets([aDaiMock.address], [MAX_UINT_AMOUNT])
+      incentivesController.configureAssets([aDaiMock.address], [MAX_UINT_AMOUNT])
     ).to.be.revertedWith('Index overflow at emissionsPerSecond');
   });
 
   it('Should REWARD_TOKEN getter returns the stake token address to keep old interface compatibility', async () => {
-    const { aaveIncentivesController, stakedToken } = testEnv;
-    await expect(await aaveIncentivesController.REWARD_TOKEN()).to.be.equal(stakedToken.address);
+    const { incentivesController, stakedToken } = testEnv;
+    await expect(await incentivesController.REWARD_TOKEN()).to.be.equal(stakedToken.address);
   });
 
   it('Should claimRewards revert if to argument is ZERO_ADDRESS', async () => {
-    const { aaveIncentivesController, users, aDaiMock } = testEnv;
+    const { incentivesController, users, aDaiMock } = testEnv;
     const [userWithRewards] = users;
 
-    await waitForTx(await aaveIncentivesController.configureAssets([aDaiMock.address], ['2000']));
+    await waitForTx(await incentivesController.configureAssets([aDaiMock.address], ['2000']));
     await waitForTx(await aDaiMock.setUserBalanceAndSupply('300000', '30000'));
 
     // Claim from third party claimer
     await expect(
-      aaveIncentivesController
+      incentivesController
         .connect(userWithRewards.signer)
         .claimRewards([aDaiMock.address], MAX_UINT_AMOUNT, ZERO_ADDRESS)
     ).to.be.revertedWith('INVALID_TO_ADDRESS');

--- a/test/StakedIncentivesController/misc.spec.ts
+++ b/test/StakedIncentivesController/misc.spec.ts
@@ -3,7 +3,7 @@ import { timeLatest, waitForTx } from '../../helpers/misc-utils';
 import { expect } from 'chai';
 
 import { makeSuite } from '../helpers/make-suite';
-import { deployAaveIncentivesController } from '../../helpers/contracts-accessors';
+import { deployStakedTokenIncentivesController } from '../../helpers/contracts-accessors';
 import { MAX_UINT_AMOUNT, RANDOM_ADDRESSES, ZERO_ADDRESS } from '../../helpers/constants';
 
 makeSuite('AaveIncentivesController misc tests', (testEnv) => {
@@ -11,7 +11,7 @@ makeSuite('AaveIncentivesController misc tests', (testEnv) => {
     const peiEmissionManager = RANDOM_ADDRESSES[1];
     const psm = RANDOM_ADDRESSES[5];
 
-    const incentivesController = await deployAaveIncentivesController([
+    const incentivesController = await deployStakedTokenIncentivesController([
       psm,
       peiEmissionManager,
     ]);

--- a/test/helpers/deploy.ts
+++ b/test/helpers/deploy.ts
@@ -1,7 +1,7 @@
 import { Signer } from 'ethers';
 import { ZERO_ADDRESS } from '../../helpers/constants';
 import {
-  deployAaveIncentivesController,
+  deployStakedTokenIncentivesController,
   deployInitializableAdminUpgradeabilityProxy,
   deployMintableErc20,
 } from '../../helpers/contracts-accessors';
@@ -34,7 +34,7 @@ export const testDeployIncentivesController = async (
     (1000 * 60 * 60).toString(),
   ]);
 
-  const incentivesImplementation = await deployAaveIncentivesController([
+  const incentivesImplementation = await deployStakedTokenIncentivesController([
     stakeProxy.address,
     emissionManagerAddress,
   ]);

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -31,10 +31,10 @@ export interface TestEnv {
   rewardsVault: SignerWithAddress;
   deployer: SignerWithAddress;
   users: SignerWithAddress[];
-  aaveToken: MintableErc20;
+  token: MintableErc20;
   aaveIncentivesController: StakedTokenIncentivesController;
   pullRewardsIncentivesController: PullRewardsIncentivesController;
-  stakedAave: StakedAaveV3;
+  stakedToken: StakedAaveV3;
   aDaiMock: ATokenMock;
   aWethMock: ATokenMock;
   aDaiBaseMock: ATokenMock;
@@ -51,8 +51,8 @@ const setBuidlerevmSnapshotId = (id: string) => {
 const testEnv: TestEnv = {
   deployer: {} as SignerWithAddress,
   users: [] as SignerWithAddress[],
-  aaveToken: {} as MintableErc20,
-  stakedAave: {} as StakedAaveV3,
+  token: {} as MintableErc20,
+  stakedToken: {} as StakedAaveV3,
   aaveIncentivesController: {} as StakedTokenIncentivesController,
   pullRewardsIncentivesController: {} as PullRewardsIncentivesController,
   aDaiMock: {} as ATokenMock,
@@ -86,10 +86,10 @@ export async function initializeMakeSuite(
   }
   testEnv.deployer = deployer;
   testEnv.rewardsVault = rewardsVault;
-  testEnv.stakedAave = starlayStake;
+  testEnv.stakedToken = starlayStake;
   testEnv.aaveIncentivesController = incentivesController;
   testEnv.pullRewardsIncentivesController = pullRewardsIncentivesController;
-  testEnv.aaveToken = starlayToken;
+  testEnv.token = starlayToken;
   testEnv.aDaiMock = await getATokenMock({ slug: 'lDai' });
   testEnv.aWethMock = await getATokenMock({ slug: 'lWeth' });
   testEnv.aDaiBaseMock = await getATokenMock({ slug: 'lDaiBase' });

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -18,9 +18,9 @@ import {
 
 chai.use(bignumberChai());
 
-export let stakedAaveInitializeTimestamp = 0;
-export const setStakedAaveInitializeTimestamp = (timestamp: number) => {
-  stakedAaveInitializeTimestamp = timestamp;
+export let stakedTokenInitializeTimestamp = 0;
+export const setStakedTokenInitializeTimestamp = (timestamp: number) => {
+  stakedTokenInitializeTimestamp = timestamp;
 };
 
 export interface SignerWithAddress {
@@ -62,9 +62,9 @@ const testEnv: TestEnv = {
 } as TestEnv;
 
 export async function initializeMakeSuite(
-  aaveToken: MintableErc20,
-  stakedAave: StakedAaveV3,
-  aaveIncentivesController: StakedTokenIncentivesController,
+  starlayToken: MintableErc20,
+  starlayStake: StakedAaveV3,
+  incentivesController: StakedTokenIncentivesController,
   pullRewardsIncentivesController: PullRewardsIncentivesController
 ) {
   const [_deployer, _proxyAdmin, ...restSigners] = await getEthersSigners();
@@ -86,10 +86,10 @@ export async function initializeMakeSuite(
   }
   testEnv.deployer = deployer;
   testEnv.rewardsVault = rewardsVault;
-  testEnv.stakedAave = stakedAave;
-  testEnv.aaveIncentivesController = aaveIncentivesController;
+  testEnv.stakedAave = starlayStake;
+  testEnv.aaveIncentivesController = incentivesController;
   testEnv.pullRewardsIncentivesController = pullRewardsIncentivesController;
-  testEnv.aaveToken = aaveToken;
+  testEnv.aaveToken = starlayToken;
   testEnv.aDaiMock = await getATokenMock({ slug: 'lDai' });
   testEnv.aWethMock = await getATokenMock({ slug: 'lWeth' });
   testEnv.aDaiBaseMock = await getATokenMock({ slug: 'lDaiBase' });

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -32,7 +32,7 @@ export interface TestEnv {
   deployer: SignerWithAddress;
   users: SignerWithAddress[];
   token: MintableErc20;
-  aaveIncentivesController: StakedTokenIncentivesController;
+  incentivesController: StakedTokenIncentivesController;
   pullRewardsIncentivesController: PullRewardsIncentivesController;
   stakedToken: StakedAaveV3;
   aDaiMock: ATokenMock;
@@ -53,7 +53,7 @@ const testEnv: TestEnv = {
   users: [] as SignerWithAddress[],
   token: {} as MintableErc20,
   stakedToken: {} as StakedAaveV3,
-  aaveIncentivesController: {} as StakedTokenIncentivesController,
+  incentivesController: {} as StakedTokenIncentivesController,
   pullRewardsIncentivesController: {} as PullRewardsIncentivesController,
   aDaiMock: {} as ATokenMock,
   aWethMock: {} as ATokenMock,
@@ -87,7 +87,7 @@ export async function initializeMakeSuite(
   testEnv.deployer = deployer;
   testEnv.rewardsVault = rewardsVault;
   testEnv.stakedToken = starlayStake;
-  testEnv.aaveIncentivesController = incentivesController;
+  testEnv.incentivesController = incentivesController;
   testEnv.pullRewardsIncentivesController = pullRewardsIncentivesController;
   testEnv.token = starlayToken;
   testEnv.aDaiMock = await getATokenMock({ slug: 'lDai' });


### PR DESCRIPTION
ver1

- rename - IAaveDistributionManager -> IDistributionManager / IAaveIncentivesController -> IIncentivesController
- modify comment in incentives contracts
- rename in test/__setup.spec, test/helpers/make-suite - aave -> starlay
- rename TestEnv - aaveToken -> token, stakedAave -> stakedToken
- rename TestEnv - aaveIncentivesController -> incentivesController
- rename deploy method for StakedTokenIncentivesController - deployAaveIncentivesController -> deployStakedTokenIncentivesController
