### PR TITLE
topic/rename contracts in stake v1

### DIFF
--- a/contracts/incentives/PullRewardsIncentivesController.sol
+++ b/contracts/incentives/PullRewardsIncentivesController.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.7.5;
 pragma experimental ABIEncoderV2;
 
-import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
-import {SafeERC20} from '@aave/aave-stake/contracts/lib/SafeERC20.sol';
+import {IERC20} from '../stake-v1/contracts/interfaces/IERC20.sol';
+import {SafeERC20} from '../stake-v1/contracts/lib/SafeERC20.sol';
 
 import {BaseIncentivesController} from './base/BaseIncentivesController.sol';
 

--- a/contracts/incentives/StakedTokenIncentivesController.sol
+++ b/contracts/incentives/StakedTokenIncentivesController.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.7.5;
 pragma experimental ABIEncoderV2;
 
-import {SafeERC20} from '@aave/aave-stake/contracts/lib/SafeERC20.sol';
-import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
+import {SafeERC20} from '../stake-v1/contracts/lib/SafeERC20.sol';
+import {IERC20} from '../stake-v1/contracts/interfaces/IERC20.sol';
 import {BaseIncentivesController} from './base/BaseIncentivesController.sol';
 import {IStakedTokenWithConfig} from '../interfaces/IStakedTokenWithConfig.sol';
 

--- a/contracts/incentives/base/BaseIncentivesController.sol
+++ b/contracts/incentives/base/BaseIncentivesController.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import {SafeMath} from '../../lib/SafeMath.sol';
 import {DistributionTypes} from '../../lib/DistributionTypes.sol';
-import {VersionedInitializable} from '@aave/aave-stake/contracts/utils/VersionedInitializable.sol';
+import {VersionedInitializable} from '../../stake-v1/contracts/utils/VersionedInitializable.sol';
 import {DistributionManager} from './DistributionManager.sol';
 import {IERC20} from '../../stake-v1/contracts/interfaces/IERC20.sol';
 import {IScaledBalanceToken} from '../../interfaces/IScaledBalanceToken.sol';

--- a/contracts/incentives/base/BaseIncentivesController.sol
+++ b/contracts/incentives/base/BaseIncentivesController.sol
@@ -6,7 +6,7 @@ import {SafeMath} from '../../lib/SafeMath.sol';
 import {DistributionTypes} from '../../lib/DistributionTypes.sol';
 import {VersionedInitializable} from '@aave/aave-stake/contracts/utils/VersionedInitializable.sol';
 import {DistributionManager} from './DistributionManager.sol';
-import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
+import {IERC20} from '../../stake-v1/contracts/interfaces/IERC20.sol';
 import {IScaledBalanceToken} from '../../interfaces/IScaledBalanceToken.sol';
 import {IIncentivesController} from '../../interfaces/IIncentivesController.sol';
 

--- a/contracts/interfaces/IStakedTokenWithConfig.sol
+++ b/contracts/interfaces/IStakedTokenWithConfig.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.7.5;
 
-import {IStakedToken} from '@aave/aave-stake/contracts/interfaces/IStakedToken.sol';
+import {IStakedToken} from '../stake-v1/contracts/interfaces/IStakedToken.sol';
 
 interface IStakedTokenWithConfig is IStakedToken {
   function STAKED_TOKEN() external view returns(address);

--- a/contracts/mocks/ATokenMock.sol
+++ b/contracts/mocks/ATokenMock.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import {IIncentivesController} from '../interfaces/IIncentivesController.sol';
 import {DistributionTypes} from '../lib/DistributionTypes.sol';
-import {IAToken} from '@aave/aave-stake/contracts/interfaces/IAToken.sol';
+import {IAToken} from '../stake-v1/contracts/interfaces/IAToken.sol';
 
 contract ATokenMock is IAToken {
   IIncentivesController public _ic;

--- a/contracts/mocks/StakeMock.sol
+++ b/contracts/mocks/StakeMock.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.7.5;
 
 import {IStakedTokenWithConfig} from '../interfaces/IStakedTokenWithConfig.sol';
-import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
+import {IERC20} from '../stake-v1/contracts/interfaces/IERC20.sol';
 
 contract StakeMock is IStakedTokenWithConfig {
   address public immutable override STAKED_TOKEN;

--- a/contracts/proposals/ProposalIncentivesExecutor.sol
+++ b/contracts/proposals/ProposalIncentivesExecutor.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.7.5;
 pragma abicoder v2;
 
-import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
+import {IERC20} from '../stake-v1/contracts/interfaces/IERC20.sol';
 import {ILendingPoolAddressesProvider} from '../interfaces/ILendingPoolAddressesProvider.sol';
 import {ILendingPoolConfigurator} from '../interfaces/ILendingPoolConfigurator.sol';
 import {IIncentivesController} from '../interfaces/IIncentivesController.sol';

--- a/contracts/stake-v1/contracts/interfaces/IAToken.sol
+++ b/contracts/stake-v1/contracts/interfaces/IAToken.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.7.5;
+
+interface IAToken {
+  function getScaledUserBalanceAndSupply(address user) external view returns (uint256, uint256);
+}

--- a/contracts/stake-v1/contracts/interfaces/IERC20.sol
+++ b/contracts/stake-v1/contracts/interfaces/IERC20.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ * From https://github.com/OpenZeppelin/openzeppelin-contracts
+ */
+interface IERC20 {
+  /**
+   * @dev Returns the amount of tokens in existence.
+   */
+  function totalSupply() external view returns (uint256);
+
+  /**
+   * @dev Returns the amount of tokens owned by `account`.
+   */
+  function balanceOf(address account) external view returns (uint256);
+
+  /**
+   * @dev Moves `amount` tokens from the caller's account to `recipient`.
+   *
+   * Returns a boolean value indicating whether the operation succeeded.
+   *
+   * Emits a {Transfer} event.
+   */
+  function transfer(address recipient, uint256 amount) external returns (bool);
+
+  /**
+   * @dev Returns the remaining number of tokens that `spender` will be
+   * allowed to spend on behalf of `owner` through {transferFrom}. This is
+   * zero by default.
+   *
+   * This value changes when {approve} or {transferFrom} are called.
+   */
+  function allowance(address owner, address spender) external view returns (uint256);
+
+  /**
+   * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+   *
+   * Returns a boolean value indicating whether the operation succeeded.
+   *
+   * IMPORTANT: Beware that changing an allowance with this method brings the risk
+   * that someone may use both the old and the new allowance by unfortunate
+   * transaction ordering. One possible solution to mitigate this race
+   * condition is to first reduce the spender's allowance to 0 and set the
+   * desired value afterwards:
+   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+   *
+   * Emits an {Approval} event.
+   */
+  function approve(address spender, uint256 amount) external returns (bool);
+
+  /**
+   * @dev Moves `amount` tokens from `sender` to `recipient` using the
+   * allowance mechanism. `amount` is then deducted from the caller's
+   * allowance.
+   *
+   * Returns a boolean value indicating whether the operation succeeded.
+   *
+   * Emits a {Transfer} event.
+   */
+  function transferFrom(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) external returns (bool);
+
+  /**
+   * @dev Emitted when `value` tokens are moved from one account (`from`) to
+   * another (`to`).
+   *
+   * Note that `value` may be zero.
+   */
+  event Transfer(address indexed from, address indexed to, uint256 value);
+
+  /**
+   * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+   * a call to {approve}. `value` is the new allowance.
+   */
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/contracts/stake-v1/contracts/interfaces/IStakedToken.sol
+++ b/contracts/stake-v1/contracts/interfaces/IStakedToken.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.5;
+
+interface IStakedToken {
+  
+  function stake(address to, uint256 amount) external;
+
+  function redeem(address to, uint256 amount) external;
+
+  function cooldown() external;
+
+  function claimRewards(address to, uint256 amount) external;
+}

--- a/contracts/stake-v1/contracts/lib/Address.sol
+++ b/contracts/stake-v1/contracts/lib/Address.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+/**
+ * @dev Collection of functions related to the address type
+ * From https://github.com/OpenZeppelin/openzeppelin-contracts
+ */
+library Address {
+  /**
+   * @dev Returns true if `account` is a contract.
+   *
+   * [IMPORTANT]
+   * ====
+   * It is unsafe to assume that an address for which this function returns
+   * false is an externally-owned account (EOA) and not a contract.
+   *
+   * Among others, `isContract` will return false for the following
+   * types of addresses:
+   *
+   *  - an externally-owned account
+   *  - a contract in construction
+   *  - an address where a contract will be created
+   *  - an address where a contract lived, but was destroyed
+   * ====
+   */
+  function isContract(address account) internal view returns (bool) {
+    // According to EIP-1052, 0x0 is the value returned for not-yet created accounts
+    // and 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is returned
+    // for accounts without code, i.e. `keccak256('')`
+    bytes32 codehash;
+    bytes32 accountHash = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      codehash := extcodehash(account)
+    }
+    return (codehash != accountHash && codehash != 0x0);
+  }
+
+  /**
+   * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+   * `recipient`, forwarding all available gas and reverting on errors.
+   *
+   * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+   * of certain opcodes, possibly making contracts go over the 2300 gas limit
+   * imposed by `transfer`, making them unable to receive funds via
+   * `transfer`. {sendValue} removes this limitation.
+   *
+   * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+   *
+   * IMPORTANT: because control is transferred to `recipient`, care must be
+   * taken to not create reentrancy vulnerabilities. Consider using
+   * {ReentrancyGuard} or the
+   * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+   */
+  function sendValue(address payable recipient, uint256 amount) internal {
+    require(address(this).balance >= amount, 'Address: insufficient balance');
+
+    // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+    (bool success, ) = recipient.call{value: amount}('');
+    require(success, 'Address: unable to send value, recipient may have reverted');
+  }
+}

--- a/contracts/stake-v1/contracts/lib/BaseAdminUpgradeabilityProxy.sol
+++ b/contracts/stake-v1/contracts/lib/BaseAdminUpgradeabilityProxy.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import './UpgradeabilityProxy.sol';
+
+/**
+ * @title BaseAdminUpgradeabilityProxy
+ * @dev From https://github.com/OpenZeppelin/openzeppelin-sdk/tree/solc-0.6/packages/lib/contracts/upgradeability
+ * This contract combines an upgradeability proxy with an authorization
+ * mechanism for administrative tasks.
+ * All external functions in this contract must be guarded by the
+ * `ifAdmin` modifier. See ethereum/solidity#3864 for a Solidity
+ * feature proposal that would enable this to be done automatically.
+ */
+contract BaseAdminUpgradeabilityProxy is BaseUpgradeabilityProxy {
+  /**
+   * @dev Emitted when the administration has been transferred.
+   * @param previousAdmin Address of the previous admin.
+   * @param newAdmin Address of the new admin.
+   */
+  event AdminChanged(address previousAdmin, address newAdmin);
+
+  /**
+   * @dev Storage slot with the admin of the contract.
+   * This is the keccak-256 hash of "eip1967.proxy.admin" subtracted by 1, and is
+   * validated in the constructor.
+   */
+
+  bytes32 internal constant ADMIN_SLOT =
+    0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+  /**
+   * @dev Modifier to check whether the `msg.sender` is the admin.
+   * If it is, it will run the function. Otherwise, it will delegate the call
+   * to the implementation.
+   */
+  modifier ifAdmin() {
+    if (msg.sender == _admin()) {
+      _;
+    } else {
+      _fallback();
+    }
+  }
+
+  /**
+   * @return The address of the proxy admin.
+   */
+  function admin() external ifAdmin returns (address) {
+    return _admin();
+  }
+
+  /**
+   * @return The address of the implementation.
+   */
+  function implementation() external ifAdmin returns (address) {
+    return _implementation();
+  }
+
+  /**
+   * @dev Changes the admin of the proxy.
+   * Only the current admin can call this function.
+   * @param newAdmin Address to transfer proxy administration to.
+   */
+  function changeAdmin(address newAdmin) external ifAdmin {
+    require(newAdmin != address(0), 'Cannot change the admin of a proxy to the zero address');
+    emit AdminChanged(_admin(), newAdmin);
+    _setAdmin(newAdmin);
+  }
+
+  /**
+   * @dev Upgrade the backing implementation of the proxy.
+   * Only the admin can call this function.
+   * @param newImplementation Address of the new implementation.
+   */
+  function upgradeTo(address newImplementation) external ifAdmin {
+    _upgradeTo(newImplementation);
+  }
+
+  /**
+   * @dev Upgrade the backing implementation of the proxy and call a function
+   * on the new implementation.
+   * This is useful to initialize the proxied contract.
+   * @param newImplementation Address of the new implementation.
+   * @param data Data to send as msg.data in the low level call.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   */
+  function upgradeToAndCall(address newImplementation, bytes calldata data)
+    external
+    payable
+    ifAdmin
+  {
+    _upgradeTo(newImplementation);
+    (bool success, ) = newImplementation.delegatecall(data);
+    require(success);
+  }
+
+  /**
+   * @return adm The admin slot.
+   */
+  function _admin() internal view returns (address adm) {
+    bytes32 slot = ADMIN_SLOT;
+    assembly {
+      adm := sload(slot)
+    }
+  }
+
+  /**
+   * @dev Sets the address of the proxy admin.
+   * @param newAdmin Address of the new proxy admin.
+   */
+  function _setAdmin(address newAdmin) internal {
+    bytes32 slot = ADMIN_SLOT;
+
+    assembly {
+      sstore(slot, newAdmin)
+    }
+  }
+
+  /**
+   * @dev Only fall back when the sender is not the admin.
+   */
+  function _willFallback() internal virtual override {
+    require(msg.sender != _admin(), 'Cannot call fallback function from the proxy admin');
+    super._willFallback();
+  }
+}

--- a/contracts/stake-v1/contracts/lib/BaseUpgradeabilityProxy.sol
+++ b/contracts/stake-v1/contracts/lib/BaseUpgradeabilityProxy.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import './Proxy.sol';
+import './Address.sol';
+
+/**
+ * @title BaseUpgradeabilityProxy
+ * @dev From https://github.com/OpenZeppelin/openzeppelin-sdk/tree/solc-0.6/packages/lib/contracts/upgradeability
+ * This contract implements a proxy that allows to change the
+ * implementation address to which it will delegate.
+ * Such a change is called an implementation upgrade.
+ */
+contract BaseUpgradeabilityProxy is Proxy {
+  /**
+   * @dev Emitted when the implementation is upgraded.
+   * @param implementation Address of the new implementation.
+   */
+  event Upgraded(address indexed implementation);
+
+  /**
+   * @dev Storage slot with the address of the current implementation.
+   * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+   * validated in the constructor.
+   */
+  bytes32 internal constant IMPLEMENTATION_SLOT =
+    0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+  /**
+   * @dev Returns the current implementation.
+   * @return impl Address of the current implementation
+   */
+  function _implementation() internal view override returns (address impl) {
+    bytes32 slot = IMPLEMENTATION_SLOT;
+    assembly {
+      impl := sload(slot)
+    }
+  }
+
+  /**
+   * @dev Upgrades the proxy to a new implementation.
+   * @param newImplementation Address of the new implementation.
+   */
+  function _upgradeTo(address newImplementation) internal {
+    _setImplementation(newImplementation);
+    emit Upgraded(newImplementation);
+  }
+
+  /**
+   * @dev Sets the implementation address of the proxy.
+   * @param newImplementation Address of the new implementation.
+   */
+  function _setImplementation(address newImplementation) internal {
+    require(
+      Address.isContract(newImplementation),
+      'Cannot set a proxy implementation to a non-contract address'
+    );
+
+    bytes32 slot = IMPLEMENTATION_SLOT;
+
+    assembly {
+      sstore(slot, newImplementation)
+    }
+  }
+}

--- a/contracts/stake-v1/contracts/lib/InitializableUpgradeabilityProxy.sol
+++ b/contracts/stake-v1/contracts/lib/InitializableUpgradeabilityProxy.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import './BaseUpgradeabilityProxy.sol';
+
+/**
+ * @title InitializableUpgradeabilityProxy
+ * @dev From https://github.com/OpenZeppelin/openzeppelin-sdk/tree/solc-0.6/packages/lib/contracts/upgradeability
+ * Extends BaseUpgradeabilityProxy with an initializer for initializing
+ * implementation and init data.
+ */
+contract InitializableUpgradeabilityProxy is BaseUpgradeabilityProxy {
+  /**
+   * @dev Contract initializer.
+   * @param _logic Address of the initial implementation.
+   * @param _data Data to send as msg.data to the implementation to initialize the proxied contract.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
+   */
+  function initialize(address _logic, bytes memory _data) public payable {
+    require(_implementation() == address(0));
+    assert(IMPLEMENTATION_SLOT == bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1));
+    _setImplementation(_logic);
+    if (_data.length > 0) {
+      (bool success, ) = _logic.delegatecall(_data);
+      require(success);
+    }
+  }
+}

--- a/contracts/stake-v1/contracts/lib/Proxy.sol
+++ b/contracts/stake-v1/contracts/lib/Proxy.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+/**
+ * @title Proxy
+ * @dev From https://github.com/OpenZeppelin/openzeppelin-sdk/tree/solc-0.6/packages/lib/contracts/upgradeability
+ * Implements delegation of calls to other contracts, with proper
+ * forwarding of return values and bubbling of failures.
+ * It defines a fallback function that delegates all calls to the address
+ * returned by the abstract _implementation() internal function.
+ */
+abstract contract Proxy {
+  /**
+   * @dev Fallback function.
+   * Implemented entirely in `_fallback`.
+   */
+  fallback() external payable {
+    _fallback();
+  }
+
+  /**
+   * @return The Address of the implementation.
+   */
+  function _implementation() internal view virtual returns (address);
+
+  /**
+   * @dev Delegates execution to an implementation contract.
+   * This is a low level function that doesn't return to its internal call site.
+   * It will return to the external caller whatever the implementation returns.
+   * @param implementation Address to delegate.
+   */
+  function _delegate(address implementation) internal {
+    assembly {
+      // Copy msg.data. We take full control of memory in this inline assembly
+      // block because it will not return to Solidity code. We overwrite the
+      // Solidity scratch pad at memory position 0.
+      calldatacopy(0, 0, calldatasize())
+
+      // Call the implementation.
+      // out and outsize are 0 because we don't know the size yet.
+      let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+      // Copy the returned data.
+      returndatacopy(0, 0, returndatasize())
+
+      switch result
+        // delegatecall returns 0 on error.
+        case 0 {
+          revert(0, returndatasize())
+        }
+        default {
+          return(0, returndatasize())
+        }
+    }
+  }
+
+  /**
+   * @dev Function that is run as the first thing in the fallback function.
+   * Can be redefined in derived contracts to add functionality.
+   * Redefinitions must call super._willFallback().
+   */
+  function _willFallback() internal virtual {}
+
+  /**
+   * @dev fallback implementation.
+   * Extracted to enable manual triggering.
+   */
+  function _fallback() internal {
+    _willFallback();
+    _delegate(_implementation());
+  }
+}

--- a/contracts/stake-v1/contracts/lib/SafeERC20.sol
+++ b/contracts/stake-v1/contracts/lib/SafeERC20.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.7.5;
+
+import {IERC20} from '../interfaces/IERC20.sol';
+import {SafeMath} from '../../../lib/SafeMath.sol';
+import {Address} from './Address.sol';
+
+/**
+ * @title SafeERC20
+ * @dev From https://github.com/OpenZeppelin/openzeppelin-contracts
+ * Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20 {
+  using SafeMath for uint256;
+  using Address for address;
+
+  function safeTransfer(
+    IERC20 token,
+    address to,
+    uint256 value
+  ) internal {
+    callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+  }
+
+  function safeTransferFrom(
+    IERC20 token,
+    address from,
+    address to,
+    uint256 value
+  ) internal {
+    callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+  }
+
+  function safeApprove(
+    IERC20 token,
+    address spender,
+    uint256 value
+  ) internal {
+    require(
+      (value == 0) || (token.allowance(address(this), spender) == 0),
+      'SafeERC20: approve from non-zero to non-zero allowance'
+    );
+    callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+  }
+
+  function callOptionalReturn(IERC20 token, bytes memory data) private {
+    require(address(token).isContract(), 'SafeERC20: call to non-contract');
+
+    // solhint-disable-next-line avoid-low-level-calls
+    (bool success, bytes memory returndata) = address(token).call(data);
+    require(success, 'SafeERC20: low-level call failed');
+
+    if (returndata.length > 0) {
+      // Return data is optional
+      // solhint-disable-next-line max-line-length
+      require(abi.decode(returndata, (bool)), 'SafeERC20: ERC20 operation did not succeed');
+    }
+  }
+}

--- a/contracts/stake-v1/contracts/lib/UpgradeabilityProxy.sol
+++ b/contracts/stake-v1/contracts/lib/UpgradeabilityProxy.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.5;
+
+import './BaseUpgradeabilityProxy.sol';
+
+/**
+ * @title UpgradeabilityProxy
+ * @dev From https://github.com/OpenZeppelin/openzeppelin-sdk/tree/solc-0.6/packages/lib/contracts/upgradeability
+ * Extends BaseUpgradeabilityProxy with a constructor for initializing
+ * implementation and init data.
+ */
+contract UpgradeabilityProxy is BaseUpgradeabilityProxy {
+  /**
+   * @dev Contract constructor.
+   * @param _logic Address of the initial implementation.
+   * @param _data Data to send as msg.data to the implementation to initialize the proxied contract.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
+   */
+  constructor(address _logic, bytes memory _data) public payable {
+    assert(IMPLEMENTATION_SLOT == bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1));
+    _setImplementation(_logic);
+    if (_data.length > 0) {
+      (bool success, ) = _logic.delegatecall(_data);
+      require(success);
+    }
+  }
+}

--- a/contracts/stake-v1/contracts/utils/VersionedInitializable.sol
+++ b/contracts/stake-v1/contracts/utils/VersionedInitializable.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.5;
+
+/**
+ * @title VersionedInitializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ *
+ * @author Aave, inspired by the OpenZeppelin Initializable contract
+ */
+abstract contract VersionedInitializable {
+  /**
+   * @dev Indicates that the contract has been initialized.
+   */
+  uint256 internal lastInitializedRevision = 0;
+
+  /**
+   * @dev Modifier to use in the initializer function of a contract.
+   */
+  modifier initializer() {
+    uint256 revision = getRevision();
+    require(revision > lastInitializedRevision, 'Contract instance has already been initialized');
+
+    lastInitializedRevision = revision;
+
+    _;
+  }
+
+  /// @dev returns the revision number of the contract.
+  /// Needs to be defined in the inherited class as a constant.
+  function getRevision() internal pure virtual returns (uint256);
+
+  // Reserved storage space to allow for layout changes in the future.
+  uint256[50] private ______gap;
+}

--- a/contracts/utils/InitializableAdminUpgradeabilityProxy.sol
+++ b/contracts/utils/InitializableAdminUpgradeabilityProxy.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import '../stake-v1/contracts/lib/BaseAdminUpgradeabilityProxy.sol';
+import '../stake-v1/contracts/lib/InitializableUpgradeabilityProxy.sol';
+
+/**
+ * @title InitializableAdminUpgradeabilityProxy
+ * @dev From https://github.com/OpenZeppelin/openzeppelin-sdk/tree/solc-0.6/packages/lib/contracts/upgradeability
+ * Extends from BaseAdminUpgradeabilityProxy with an initializer for
+ * initializing the implementation, admin, and init data.
+ */
+contract InitializableAdminUpgradeabilityProxy is
+  BaseAdminUpgradeabilityProxy,
+  InitializableUpgradeabilityProxy
+{
+  /**
+   * Contract initializer.
+   * @param _logic address of the initial implementation.
+   * @param _admin Address of the proxy administrator.
+   * @param _data Data to send as msg.data to the implementation to initialize the proxied contract.
+   * It should include the signature and the parameters of the function to be called, as described in
+   * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+   * This parameter is optional, if no data is given the initialization call to proxied contract will be skipped.
+   */
+  function initialize(
+    address _logic,
+    address _admin,
+    bytes memory _data
+  ) public payable {
+    require(_implementation() == address(0));
+    InitializableUpgradeabilityProxy.initialize(_logic, _data);
+    assert(ADMIN_SLOT == bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1));
+    _setAdmin(_admin);
+  }
+
+  /**
+   * @dev Only fall back when the sender is not the admin.
+   */
+  function _willFallback() internal override(BaseAdminUpgradeabilityProxy, Proxy) {
+    BaseAdminUpgradeabilityProxy._willFallback();
+  }
+}

--- a/contracts/utils/InitializableAdminUpgradeabilityProxy.sol.sol
+++ b/contracts/utils/InitializableAdminUpgradeabilityProxy.sol.sol
@@ -1,1 +1,0 @@
-import '@aave/aave-stake/contracts/lib/InitializableAdminUpgradeabilityProxy.sol';


### PR DESCRIPTION
remove dependencies to `@aave/aave-stake`

TODO
- Bring back the source of `StakedAaveV3.sol`
- remove `@aave/aave-stake`