### PR TITLE
topic/add protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "submodule-stake"]
 	path = submodule-stake
 	url = https://github.com/starlay-finance/starlay-stake
+[submodule "submodule-protocol"]
+	path = submodule-protocol
+	url = https://github.com/starlay-finance/starlay-protocol

--- a/contracts/interfaces/ILendingPool.sol
+++ b/contracts/interfaces/ILendingPool.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity ^0.6.12;
 
-import '@aave/protocol-v2/contracts/interfaces/ILendingPool.sol';
+import '../../submodule-protocol/contracts/interfaces/ILendingPool.sol';

--- a/contracts/lending-pool/AToken.sol
+++ b/contracts/lending-pool/AToken.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity ^0.6.12;
 
-import '@aave/protocol-v2/contracts/protocol/tokenization/AToken.sol';
+import '../../submodule-protocol/contracts/protocol/tokenization/AToken.sol';

--- a/contracts/lending-pool/AaveProtocolDataProvider.sol
+++ b/contracts/lending-pool/AaveProtocolDataProvider.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: agpl-3.0
-pragma solidity ^0.6.12;
-
-import '@aave/protocol-v2/contracts/misc/AaveProtocolDataProvider.sol';

--- a/contracts/lending-pool/StarlayProtocolDataProvider.sol
+++ b/contracts/lending-pool/StarlayProtocolDataProvider.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.6.12;
+
+import '../../submodule-protocol/contracts/misc/StarlayProtocolDataProvider.sol';

--- a/contracts/lending-pool/VariableDebtToken.sol
+++ b/contracts/lending-pool/VariableDebtToken.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity ^0.6.12;
 
-import '@aave/protocol-v2/contracts/protocol/tokenization/VariableDebtToken.sol';
+import '../../submodule-protocol/contracts/protocol/tokenization/VariableDebtToken.sol';

--- a/contracts/utils/MintableErc20.sol
+++ b/contracts/utils/MintableErc20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity 0.6.12;
 
-import {ERC20} from '@aave/protocol-v2/contracts/dependencies/openzeppelin/contracts/ERC20.sol';
+import {ERC20} from '../../submodule-protocol/contracts/dependencies/openzeppelin/contracts/ERC20.sol';
 
 /**
  * @title ERC20Mintable

--- a/tasks/deployment/deploy-reserve-implementations.ts
+++ b/tasks/deployment/deploy-reserve-implementations.ts
@@ -1,6 +1,6 @@
 import { task } from 'hardhat/config';
 import {
-  AaveProtocolDataProvider__factory,
+  StarlayProtocolDataProvider__factory,
   ILendingPoolAddressesProvider__factory,
 } from '../../types';
 
@@ -23,7 +23,7 @@ task(
 
     // Instances
     const poolProvider = await ILendingPoolAddressesProvider__factory.connect(provider, deployer);
-    const protocolDataProvider = await AaveProtocolDataProvider__factory.connect(
+    const protocolDataProvider = await StarlayProtocolDataProvider__factory.connect(
       await poolProvider.getAddress(
         '0x0100000000000000000000000000000000000000000000000000000000000000'
       ),

--- a/tasks/misc/verify-proposal-etherscan.ts
+++ b/tasks/misc/verify-proposal-etherscan.ts
@@ -1,6 +1,6 @@
 import { task } from 'hardhat/config';
 import {
-  AaveProtocolDataProvider__factory,
+  StarlayProtocolDataProvider__factory,
   IERC20Detailed__factory,
   ILendingPool,
   ILendingPoolAddressesProvider__factory,
@@ -43,7 +43,7 @@ task('verify-proposal-etherscan', 'Verify proposals')
       POOL_PROVIDER,
       deployer
     );
-    const protocolDataProvider = await AaveProtocolDataProvider__factory.connect(
+    const protocolDataProvider = await StarlayProtocolDataProvider__factory.connect(
       await poolProvider.getAddress(
         '0x0100000000000000000000000000000000000000000000000000000000000000'
       ),

--- a/test-fork/helpers.ts
+++ b/test-fork/helpers.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { tEthereumAddress } from '../helpers/types';
 import {
-  AaveProtocolDataProvider__factory,
+  StarlayProtocolDataProvider__factory,
   AToken__factory,
   IERC20__factory,
   ILendingPoolAddressesProvider__factory,
@@ -61,7 +61,7 @@ export const getReserveConfigs = async (
     poolProviderAddress,
     proposer
   );
-  const protocolDataProvider = await AaveProtocolDataProvider__factory.connect(
+  const protocolDataProvider = await StarlayProtocolDataProvider__factory.connect(
     await poolProvider.getAddress(
       '0x0100000000000000000000000000000000000000000000000000000000000000'
     ),


### PR DESCRIPTION
use in https://github.com/starlay-finance/starlay-protocol to not use @aave/protocol-v2

- add starlay-protocol as submodule (instead of @aave/protocol-v2 npm package)
- use StarlayProtocolDataProvider (in starlay-protocol) instead of AaveProtocolDataProvider
- use ILendingPool,AToken,VariableDebtToken,MintableErc20 (in starlay-protocol) instead of @aave/protocol-v2 contracts
